### PR TITLE
add setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,10 @@
+from setuptools import setup, find_packages
+
+setup(
+    name="memory_leak",
+    packages=find_packages(),
+    include_package_data=True,
+    install_requires=[
+        "pympler",
+    ],
+)


### PR DESCRIPTION
便利なパッケージをありがとうございます。
より使いやすくするために最小限のsetup.pyを追加してみました。

Memory_leakディレクトリ内で`python -m pip install . ` を実行するとpythonパッケージとしてインストールされて

どこにいても
```python
import memory_leak
```
によりコードをインポートできるようになります。